### PR TITLE
Qt backend

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -15,6 +15,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
     texlive texlive-latex-extra \
     dvipng dvisvgm
 
+# Set entrypoint
+RUN echo '#!/usr/bin/env bash' > /start && \
+    echo 'xvfb-run "$@"' >> /start && \
+    chmod +x /start
+ENTRYPOINT ["/start"]
+
 # Switch to notebook user
 USER $NB_USER
 WORKDIR /home/${NB_USER}
@@ -24,10 +30,6 @@ RUN python -m pip install nbgitpuller octave_kernel
 
 # Install Octave extensions
 RUN octave-cli --eval 'pkg install -forge tablicious'
-
-# Set entrypoint
-COPY ./start /
-ENTRYPOINT ["/start"]
 
 # Switch to main octave executable ('octave-cli' doesn't have 'qt')
 ENV OCTAVE_EXECUTABLE=octave

--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/mathworks-ref-arch/matlab-integration-for-jupyter/jupyter-matlab-no
 
 # Switch to root user
 USER root
-ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
+ENV DEBIAN_FRONTEND="noninteractive" TZ="UTC"
 
 # Install Octave
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
@@ -21,3 +21,13 @@ WORKDIR /home/${NB_USER}
 
 # Install nbgitpuller and octave_kernel
 RUN python -m pip install nbgitpuller octave_kernel
+
+# Install Octave extensions
+RUN octave-cli --eval 'pkg install -forge tablicious'
+
+# Set entrypoint
+COPY ./start /
+ENTRYPOINT ["/start"]
+
+# Switch to main octave executable ('octave-cli' doesn't have 'qt')
+ENV OCTAVE_EXECUTABLE=octave

--- a/.binder/start
+++ b/.binder/start
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+#xvfb-run exec "$@"
+xvfb-run "$@"

--- a/.binder/start
+++ b/.binder/start
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-#xvfb-run exec "$@"
-xvfb-run "$@"


### PR DESCRIPTION
Improve Octave's kernel plotting quality by using the Qt backend via `xvfb-run`.

In addition, pre-install `tablicious`.